### PR TITLE
Fix: invalid orm config given error when try to run migrations.

### DIFF
--- a/ormconfig2.js
+++ b/ormconfig2.js
@@ -2,7 +2,7 @@ module.exports = {
   type: "postgres",
   synchronize: false,
   logging: true,
-  entities: [`${__dirname}/**/entities/*{.ts,.js}`],
+  entities: [`${__dirname}/**/src/entities/*{.ts,.js}`],
   migrations: [`${__dirname}/**/migration/*.ts`],
   url: process.env.DATABASE_URL,
   cli: {


### PR DESCRIPTION
Erro que estava acontecendo ao tentar rodar as migrations:
![Screenshot 2024-03-31 at 11 12 35](https://github.com/VitoorFranca/payments/assets/70482627/676d15f8-0af7-4da3-b521-bdab0d6c92bc)

nest js problem issue argue:
https://github.com/nestjs/schematics/issues/470


Como recriar o erro ?
Coloque o arquivo "ormconfig2.js" como o principal para rodar as migrations e tente executar o comando do package.json para rodar as migrations
